### PR TITLE
ENH adding python 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,3 @@ Feedstock Maintainers
 * [@JamesMakela-NOAA](https://github.com/JamesMakela-NOAA/)
 * [@jay-hennen](https://github.com/jay-hennen/)
 
-
-<!-- dummy commit to enable rerendering -->
-

--- a/README.md
+++ b/README.md
@@ -188,3 +188,6 @@ Feedstock Maintainers
 * [@JamesMakela-NOAA](https://github.com/JamesMakela-NOAA/)
 * [@jay-hennen](https://github.com/jay-hennen/)
 
+
+<!-- dummy commit to enable rerendering -->
+

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,2 @@
+python:
+  - 2.7.* *_cpython  # [not (aarch64 or ppc64le or win)]]


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added python 2.7 as instructed in #10.

Merge this PR to enable Python 2.7. Note that you may need to merge this PR into a new branch on the feedstock to enable Python 2.7 while also keeping `win`, `aarch64`, `ppc64le`, or other Python builds working.

**WARNING: Python 2.7 reached end-of-life on 2020-01-01. `conda-forge` provides no support for Python 2.7 builds and all existing builds are provided on an "as-is" basis. Python 2.7 builds on the `win` platform are not possible since we do not build against `vs2008` in our CI providers. We also do not support Python 2.7 builds on the `aarch64` or `ppc64le` platforms.**



Here's a checklist to do before merging.
- [ ] Bump the build number if needed.

Fixes #10